### PR TITLE
Do not expand `java.home` from build machine in flattened POM

### DIFF
--- a/maven-jellydoc-plugin/pom.xml
+++ b/maven-jellydoc-plugin/pom.xml
@@ -47,6 +47,28 @@
           </execution>
         </executions>
       </plugin>
+      <!--
+        This is necessary to ensure that java.home from the build machine doesn't get expanded in
+        the tools.jar dependency below. When we migrate to Java 11 APIs, this should be deleted.
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <pomElements>
+                <profiles>keep</profiles>
+              </pomElements>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Amends #2. I noticed in doing some unrelated testing that `flatten-maven-plugin` (enabled when we incrementalized this plugin) flattens `java.home` from the build machine, which we do not want to do.