### PR TITLE
set maven libs according to consumers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     ignore:
       # Ignore 1.2.0-atlassian-2
       - dependency-name: "jaxen:jaxen"
+      # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
+      - dependency-name: "org.apache.maven:*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/maven-jellydoc-plugin/pom.xml
+++ b/maven-jellydoc-plugin/pom.xml
@@ -66,7 +66,7 @@
   </build>
 
   <properties>
-    <maven.version>3.9.0</maven.version>
+    <maven.version>3.8.1</maven.version>
     <plexus.version>2.1.1</plexus.version>
     <maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
     <!-- TODO fix violations -->
@@ -75,6 +75,10 @@
     <maven.site.skip>true</maven.site.skip>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
   </properties>
+
+  <prerequisites>
+      <maven>${maven.version}</maven>
+  </prerequisites>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
use a version of maven libs that we expect to be satisfied by consumers.

cf https://github.com/jenkinsci/maven-hpi-plugin/pull/440#issuecomment-1454825697

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
